### PR TITLE
DB Push-Pull in Multisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Url of the Wordpress root installation on the local server (used by search-repla
 * `set :local_tmp_dir`<br/>
 A local temp dir which is read and writeable. Defaults to `/tmp`.
 
+* `set :wpcli_args`<br/>
+You can pass arguments directly to WPCLI using this var. For example `--network` for a Wordpress Multisite installation.
+
 ## Contributing
 
 1. Fork it ( https://github.com/lavmeiker/capistrano-wpcli/fork )

--- a/lib/capistrano/tasks/wpdb.rake
+++ b/lib/capistrano/tasks/wpdb.rake
@@ -10,6 +10,10 @@ namespace :load do
 
     # A local temp dir which is read and writeable
     set :local_tmp_dir, "/tmp"
+
+    # You can pass arguments directly to WPCLI using
+    # this var
+    set :wpcli_args, "--skip-columns=guid"
     
     # Temporal db dumps path
     set :wpcli_remote_db_file, "#{fetch(:tmp_dir)}/wpcli_database.sql"
@@ -31,7 +35,7 @@ namespace :wpcli do
         run_locally do
           execute :wp, "db import", fetch(:wpcli_local_db_file)
           execute :rm, "#{fetch(:wpcli_local_db_file)}"
-          execute :wp, "search-replace", fetch(:wpcli_remote_url), fetch(:wpcli_local_url), "--skip-columns=guid"
+          execute :wp, "search-replace", fetch(:wpcli_remote_url), fetch(:wpcli_local_url), fetch(:wpcli_args)
         end
       end
     end
@@ -52,7 +56,7 @@ namespace :wpcli do
         within release_path do
           execute :wp, "db import", fetch(:wpcli_remote_db_file)
           execute :rm, fetch(:wpcli_remote_db_file)
-          execute :wp, "search-replace", fetch(:wpcli_local_url), fetch(:wpcli_remote_url), "--skip-columns=guid"
+          execute :wp, "search-replace", fetch(:wpcli_local_url), fetch(:wpcli_remote_url), fetch(:wpcli_args)
         end
       end
     end


### PR DESCRIPTION
Hello,
Love the tool and have it mostly working with my WP deployments. However, the 'wp search-replace' command in the push/pull tasks doesn't work in multisite installations. Wp-cli has a --network flag that allows search-replace in the multisite tables as well. I would like to test the --network option but haven't went so far as to fork, change, and rebuild. Wanted to run by you first.

Perhaps it would be possible to have an 'args' or similar configuration, e.g. set :wpcli_args, "--network". You could then fetch this config as part of the execute and end up with something like this:
execute :wp, "search-replace", "'#{fetch(:local_url)}' '#{fetch(:remote_url)}' '#{fetch(:wpcli_args)}' --skip-columns=guid"

Thoughts? I'm very new to ruby so treading lightly.
Thanks,
~John
