### PR TITLE
Fix wpcli:db:pull for vagrant machine

### DIFF
--- a/lib/capistrano/tasks/wpdb.rake
+++ b/lib/capistrano/tasks/wpdb.rake
@@ -32,6 +32,7 @@ namespace :wpcli do
       unless roles(:dev).empty?
         on roles(:dev) do
           within fetch(:dev_path) do
+            upload! fetch(:wpcli_local_db_file), fetch(:wpcli_local_db_file)
             execute :gunzip, "<", fetch(:wpcli_local_db_file), "|", :wp, :db, :import, "-"
             execute :rm, fetch(:wpcli_local_db_file)
             execute :wp, "search-replace", fetch(:wpcli_remote_url), fetch(:wpcli_local_url), fetch(:wpcli_args) || "--skip-columns=guid"


### PR DESCRIPTION
It breaks readability though, because as I understand the convention should be that 
remote - is your hosting
local - is your vagrant, BUT

from `web` role task our local is your local machine not Vagrant.

hence variable name conventions break a bit