### PR TITLE
Add an example for wpcli:run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The following tasks are added to Capistrano:
 
 * `wpcli:run`<br/>
 Executes the WP-CLI command passed as parameter.
+Example: `cap production wpcli:run["core language install fr_FR"]`
 * `wpcli:db:push`<br/>
 Pushes the local WP database to the remote server and replaces the urls.
 * `wpcli:db:pull`<br/>


### PR DESCRIPTION
Just added an example for `wpcli:run` command.

It is not easy to find the correct format if we are not friendly with Capistrano environment.

Thanks.