### PR TITLE
Ensure :wp is first in execute argument list

### DIFF
--- a/lib/capistrano/tasks/wpdb.rake
+++ b/lib/capistrano/tasks/wpdb.rake
@@ -32,9 +32,12 @@ namespace :wpcli do
       unless roles(:dev).empty?
         on roles(:dev) do
           within fetch(:dev_path) do
+            local_tmp_file = fetch(:wpcli_local_db_file).gsub(/\.gz$/, "")
+
             upload! fetch(:wpcli_local_db_file), fetch(:wpcli_local_db_file)
-            execute :gunzip, "<", fetch(:wpcli_local_db_file), "|", :wp, :db, :import, "-"
-            execute :rm, fetch(:wpcli_local_db_file)
+            execute :gunzip, "-c", fetch(:wpcli_local_db_file), ">", local_tmp_file
+            execute :wp, :db, :import, local_tmp_file
+            execute :rm, fetch(:wpcli_local_db_file), local_tmp_file
             execute :wp, "search-replace", fetch(:wpcli_remote_url), fetch(:wpcli_local_url), fetch(:wpcli_args) || "--skip-columns=guid", "--url=" + fetch(:wpcli_remote_url)
           end
         end
@@ -43,8 +46,11 @@ namespace :wpcli do
         end
       else
         run_locally do
-          execute :gunzip, "<", fetch(:wpcli_local_db_file), "|", :wp, :db, :import, "-"
-          execute :rm, fetch(:wpcli_local_db_file)
+          local_tmp_file = fetch(:wpcli_local_db_file).gsub(/\.gz$/, "")
+
+          execute :gunzip, "-c", fetch(:wpcli_local_db_file), ">", local_tmp_file
+          execute :wp, :db, :import, local_tmp_file
+          execute :rm, fetch(:wpcli_local_db_file), local_tmp_file
           execute :wp, "search-replace", fetch(:wpcli_remote_url), fetch(:wpcli_local_url), fetch(:wpcli_args) || "--skip-columns=guid", "--url=" + fetch(:wpcli_remote_url)
         end
       end
@@ -67,8 +73,11 @@ namespace :wpcli do
       on roles(:web) do
         upload! fetch(:wpcli_local_db_file), fetch(:wpcli_remote_db_file)
         within release_path do
-          execute :gunzip, "<", fetch(:wpcli_remote_db_file), "|", :wp, :db, :import, "-"
-          execute :rm, fetch(:wpcli_remote_db_file)
+          remote_tmp_file = fetch(:wpcli_remote_db_file).gsub(/\.gz$/, "")
+
+          execute :gunzip, "-c", fetch(:wpcli_remote_db_file), ">", remote_tmp_file
+          execute :wp, :db, :import, remote_tmp_file
+          execute :rm, fetch(:wpcli_remote_db_file), remote_tmp_file
           execute :wp, "search-replace", fetch(:wpcli_local_url), fetch(:wpcli_remote_url), fetch(:wpcli_args) || "--skip-columns=guid", "--url=" + fetch(:wpcli_local_url)
         end
       end


### PR DESCRIPTION
SSKKit only allows using `command_map` on the first argument of the `execute` method (https://github.com/capistrano/sshkit/issues/48).
Trying to use this on a shared staging environment where I am unable to install `wp` as a global command resulted in using:
```ruby
SSHKit.config.command_map[:wp] = "$(if [ $(which wp) ]; then echo 'wp'; else echo 'php55-cli #{shared_path.join(wp-cli.phar)'; fi)"
```
(See #18)

This is my current solution so that I am able to override `wp` and keep the same functionality.