### PR TITLE
Implements wpcli:db:export task

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,14 @@ The following tasks are added to Capistrano:
 Executes the WP-CLI command passed as parameter.
 Example: `cap production wpcli:run["core language install fr_FR"]`
 * `wpcli:db:push`<br/>
-Pushes the local WP database to the remote server and replaces the urls.
+Pushes the local WP database to the remote server and replaces the urls.<br/>
+Use `backup_dir="/some/path"` argument to backup the remote database before push.<br/>
+Example: `cap production wpcli:db:push backup_dir="."`
 * `wpcli:db:pull`<br/>
 Pulls the remote server WP database to local and replaces the urls.
+* `wpcli:db:export`<br/>
+Pulls the remote server WP database locally, uses `local_backup_directory` to define the location of the export.<br/>
+Override export location with `backup="/some/path"` argument.
 * `wpcli:rewrite:flush`<br/>
 Flush rewrite rules.
 * `wpcli:rewrite:hard_flush`<br/>
@@ -58,6 +63,9 @@ Url of the Wordpress root installation on the local server (used by search-repla
 
 * `set :local_tmp_dir`<br/>
 A local temp dir which is read and writeable. Defaults to `/tmp`.
+
+* `set :local_backup_dir`<br/>
+A local dir which is read and writeable. Defaults to `backup`.
 
 * `set :wpcli_args`<br/>
 You can pass arguments directly to WPCLI using this var. By default it will try to load values from `ENV['WPCLI_ARGS']`.

--- a/lib/capistrano/tasks/wpdb.rake
+++ b/lib/capistrano/tasks/wpdb.rake
@@ -79,5 +79,15 @@ namespace :wpcli do
         end
       end
     end
+
+    desc "Export the remote database"
+    task :export do
+      on roles(:web) do
+        within release_path do
+          execute :wp, :db, :export, "- |", :gzip, ">", fetch(:wpcli_remote_db_file)
+          download! fetch(:wpcli_remote_db_file), "."
+        end
+      end
+    end
   end
 end

--- a/lib/capistrano/tasks/wpdb.rake
+++ b/lib/capistrano/tasks/wpdb.rake
@@ -11,6 +11,9 @@ namespace :load do
     # A local temp dir which is read and writeable
     set :local_tmp_dir, "/tmp"
 
+    # A local backup dir which is read and writeable
+    set :local_backup_dir, "backup"
+
     # Temporal db dumps path
     set :wpcli_remote_db_file, -> {"#{fetch(:tmp_dir)}/wpcli_database.sql.gz"}
     set :wpcli_local_db_file, -> {"#{fetch(:local_tmp_dir)}/wpcli_database.sql.gz"}
@@ -84,10 +87,13 @@ namespace :wpcli do
     task :export do
       on roles(:web) do
         within release_path do
+          backup_dir = ENV["backup_dir"] || fetch(:local_backup_dir)
           execute :wp, :db, :export, "- |", :gzip, ">", fetch(:wpcli_remote_db_file)
-          download! fetch(:wpcli_remote_db_file), "."
+          download! fetch(:wpcli_remote_db_file), backup_dir
         end
       end
     end
+
+    before :push, :export if ENV["backup_dir"]
   end
 end


### PR DESCRIPTION
Creates a new task within the `wpcli:db` namespace which copies the remote database to the local machine.

Also includes the option for exporting the remote database before a `db:push` by setting the `backup_dir` argument.