### PR TITLE
Utilize ssh_options for setting rsync port.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,30 +26,66 @@ All you need to do is put the following in `Capfile` file:
 
     require 'capistrano/wpcli'
 
-### How it works
+### How it works (Tasks)
 
-The following tasks are added to Capistrano:
+    wpcli:run
 
-* `wpcli:run`<br/>
-Executes the WP-CLI command passed as parameter.<br/>
-Example: `cap production wpcli:run["core language install fr_FR"]`
-* `wpcli:db:push`<br/>
-Pushes the local WP database to the remote server and replaces the urls.<br/>
-Optionally backs up the remote database before pushing (if `wpcli_backup_db` is set to true, see Configuration).<br/>
-Example: `cap production wpcli:db:push`
-* `wpcli:db:pull`<br/>
+Executes the WP-CLI command passed as parameter.
+
+    cap production wpcli:run["core language install fr_FR"]
+
+- - -
+
+    wpcli:db:push
+
+Pushes the local WP database to the remote server and replaces the urls.
+
+Optionally backs up the remote database before pushing (if `wpcli_backup_db` is set to true, see Configuration).
+
+    cap production wpcli:db:push
+
+- - -
+
+    wpcli:db:pull
+
 Pulls the remote server WP database to local and replaces the urls.
-* `wpcli:db:backup:remote`<br/>
+
+    cap production wpcli:db:pull
+
+- - -
+
+    wpcli:db:backup:remote
+
 Pulls the remote server WP database to localhost, uses `wpcli_local_db_backup_dir` to define the location of the export.
-* `wpcli:db:backup:local`<br/>
-Backs up the local WP database, uses `wpcli_local_db_backup_dir` to define the location of the export.
-* `wpcli:rewrite:flush`<br/>
+
+- - -
+
+    wpcli:db:backup:local
+
+Backs up the local WP database to localhost, uses `wpcli_local_db_backup_dir` to define the location of the export.
+
+- - -
+
+    wpcli:rewrite:flush
+
 Flush rewrite rules.
-* `wpcli:rewrite:hard_flush`<br/>
-Perform a hard flush - update `.htaccess` rules as well as rewrite rules in database.
-* `wpcli:uploads:rsync:push`<br/>
+
+- - -
+
+    wpcli:rewrite:hard_flush
+
+Perform a hard flush - updates `.htaccess` rules as well as rewrite rules in database.
+
+- - -
+
+    wpcli:uploads:rsync:push
+
 Push local uploads delta to remote machine using rsync.
-* `wpcli:uploads:rsync:pull`<br/>
+
+- - -
+
+    wpcli:uploads:rsync:pull
+
 Pull remote uploads delta to local machine using rsync.
 
 ### Configuration
@@ -58,43 +94,83 @@ This plugin needs some configuration to work properly. You can put all your conf
 
 Here's the list of options and the defaults for each option:
 
-* `set :wpcli_remote_url`<br/>
+- - -
+
+    set :wpcli_remote_url
+
 Url of the WP root installation on the remote server (used by search-replace command).
 
-* `set :wpcli_local_url`<br/>
+- - -
+
+    set :wpcli_local_url
+
 Url of the WP root installation on the local server (used by search-replace command).
 
-* `set :local_tmp_dir`<br/>
-Absolute path to local directory temporary directory which is read and writeable. Defaults to `/tmp`.
+- - -
 
-* `set :wpcli_backup_db`<br/>
+    set :local_tmp_dir
+
+Absolute path to local directory temporary directory which is read and writeable.
+
+Defaults to `/tmp`
+
+- - -
+
+    set :wpcli_backup_db
+
 Set to true if you would like to create backups of databases on each push. Defaults to false.
 
-* `set :wpcli_local_db_backup_dir`<br/>
-Absolute or relative path to local directory for storing database backups which is read and writeable. Defaults to `config/backup`.<br/>
-IMPORTANT: Make sure to add the folder to .gitignore to prevent db backups from being in version control.
+- - -
 
-* `set :wpcli_args`<br/>
-You can pass arguments directly to WPCLI using this var. By default it will try to load values from `ENV['WPCLI_ARGS']`.
+    set :wpcli_local_db_backup_dir
 
-* `set :wpcli_local_uploads_dir`<br/>
-Absolute or relative path to local WP uploads directory. Defaults to 'web/app/uploads/'.<br/>
-IMPORTANT: Add trailing slash!
+Absolute or relative path to local directory for storing database backups which is read and writeable.
 
-* `set :wpcli_remote_uploads_dir`<br/>
-Absolute path to remote wordpress uploads directory. Defaults to "#{shared_path.to_s}/web/app/uploads/".<br/>
-IMPORTANT: Add trailing slash!
+Defaults to `config/backup`
 
-* `set :wpcli_rsync_port`<br/>
-If you for whatever reason need to set a different port for rsync you can do so by setting this var. Defaults to undefined.<br/>
+**IMPORTANT: Make sure to add the folder to .gitignore to prevent db backups from being in version control.**
+
+- - -
+
+    set :wpcli_args
+
+You can pass arguments directly to WPCLI using this var.
+
+Defaults to `ENV['WPCLI_ARGS']`
+
+- - -
+
+    set :wpcli_local_uploads_dir
+
+Absolute or relative path to local WP uploads directory.
+
+Defaults to `web/app/uploads/`.
+
+**IMPORTANT: Add trailing slash!**
+
+- - -
+
+    set :wpcli_remote_uploads_dir
+
+Absolute path to remote wordpress uploads directory.
+
+Defaults to `#{shared_path.to_s}/web/app/uploads/`
+
+**IMPORTANT: Add trailing slash!**
+
+### FAQ
+
+- What if i want to use a custom port for rsync?
+  You can by setting your port somewhere inside the :ssh_options precedence.
+  See here: http://capistranorb.com/documentation/advanced-features/properties/#precedence
 
 ### Vagrant
 
 If you are using another machine as a development server (Vagrant for example), you should define a `dev` role and indicate the path where the project lives on that server. This normally goes on `deploy.rb` file. Here's an example:
 
-`server "example.dev", user: 'vagrant', password: 'vagrant', roles: %w{dev}`
+    server "example.dev", user: 'vagrant', password: 'vagrant', roles: %w{dev}
 
-`set :dev_path, '/srv/www/example.dev/current'`
+    set :dev_path, '/srv/www/example.dev/current'
 
 ## Contributing
 

--- a/lib/capistrano/tasks/wpuploads.rake
+++ b/lib/capistrano/tasks/wpuploads.rake
@@ -1,21 +1,10 @@
 namespace :load do
   task :defaults do
 
-    class Object
-      def blank?
-        respond_to?(:empty?) ? empty? : !self
-      end
-    end
-
     # These options are passed directly to rsync
     # Append your options, overwriting the defaults may result in malfunction
     # Ex: --recursive --delete --exclude .git*
-    set :wpcli_rsync_options, "-avz --rsh=ssh"
-
-    # To use a different port for ssh use the wpcli_rsync_port variable.
-    unless fetch(:wpcli_rsync_port).blank?
-      set :wpcli_rsync_options, "-avz --rsh=ssh -e 'ssh -p #{fetch(:wpcli_rsync_port)}'"
-    end
+    set :wpcli_rsync_options, "-avz --rsh=ssh --progress"
 
     # Local dir where WP stores the uploads
     # IMPORTANT: Add trailing slash!
@@ -31,9 +20,13 @@ end
 namespace :wpcli do
   namespace :uploads do
     namespace :rsync do
+
       desc "Push local uploads delta to remote machine"
       task :push do
         roles(:web).each do |role|
+          puts role.netssh_options[:port]
+          port = role.netssh_options[:port] || 22
+          set :wpcli_rsync_options, fetch(:wpcli_rsync_options) + (" -e 'ssh -p #{port}'")
           run_locally do
             execute :rsync, fetch(:wpcli_rsync_options), fetch(:wpcli_local_uploads_dir), "#{role.user}@#{role.hostname}:#{fetch(:wpcli_remote_uploads_dir)}"
           end

--- a/lib/capistrano/wpcli/version.rb
+++ b/lib/capistrano/wpcli/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Wpcli
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end


### PR DESCRIPTION
It is now possible to influence the port used for rsync via ssh_options.