### PR TITLE
Drop patch version from twiddle-wakka versioning syntax

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,15 +2,15 @@ PATH
   remote: .
   specs:
     capistrano-wpcli (0.1.3)
-      capistrano (~> 3.6.0)
-      sshkit (~> 1.11.2)
+      capistrano (~> 3.6)
+      sshkit (~> 1.11)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    airbrussh (1.1.0)
+    airbrussh (1.1.1)
       sshkit (>= 1.6.1, != 1.7.0)
-    capistrano (3.6.0)
+    capistrano (3.7.1)
       airbrussh (>= 1.0.0)
       capistrano-harrow
       i18n
@@ -21,8 +21,8 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (3.2.0)
-    rake (11.2.2)
-    sshkit (1.11.2)
+    rake (11.3.0)
+    sshkit (1.11.5)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
 
@@ -30,9 +30,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.12.5)
+  bundler (~> 1.12)
   capistrano-wpcli!
-  rake (~> 11.2.2)
+  rake (~> 11.2)
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/capistrano-wpcli.gemspec
+++ b/capistrano-wpcli.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'capistrano', '~> 3.6.0'
-  spec.add_dependency 'sshkit', '~> 1.11.2'
+  spec.add_dependency 'capistrano', '~> 3.6'
+  spec.add_dependency 'sshkit', '~> 1.11'
 
-  spec.add_development_dependency "bundler", "~> 1.12.5"
-  spec.add_development_dependency "rake", "~> 11.2.2"
+  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "rake", "~> 11.2"
 
 end


### PR DESCRIPTION
Using "twiddle-wakka" syntax with a version number including the patch level essentially locks the dependancy to that version (see http://guides.rubygems.org/patterns/#pessimistic-version-constraint)

This changes the gemspec to the minor version, which should allow it to float to any minor version before the next major version.